### PR TITLE
Fix white background not showing in WebView

### DIFF
--- a/Sources/MarkdownViewer/Resources/index.html
+++ b/Sources/MarkdownViewer/Resources/index.html
@@ -11,7 +11,7 @@
         body {
             margin: 0;
             padding: 0;
-            background: transparent;
+            background: #ffffff;
         }
         .markdown-body {
             background-color: transparent;


### PR DESCRIPTION
## Summary
- Set body background to `#ffffff` instead of `transparent` in `index.html`
- WKWebView has `drawsBackground` disabled, causing the macOS window background color to show through instead of white

## Test plan
- [ ] Open a markdown file and verify the background is white
- [ ] Verify dark mode still works correctly if applicable

🤖 Generated with [Claude Code](https://claude.com/claude-code)