### PR TITLE
Add diff toggle feature with toolbar button and menu

### DIFF
--- a/Sources/CCPlanView/AppDelegate.swift
+++ b/Sources/CCPlanView/AppDelegate.swift
@@ -1,9 +1,11 @@
 import AppKit
 import SwiftUI
+
 @MainActor
 final class AppDelegate: NSObject, NSApplicationDelegate {
     fileprivate static let titlebarHeight: CGFloat = 52
     fileprivate static let windowButtonsWidth: CGFloat = 70
+    fileprivate static let toolbarButtonsWidth: CGFloat = 50
     static let windowFrameKey = "CCPlanViewWindowFrame"
 
     func applicationDidFinishLaunching(_ notification: Notification) {
@@ -100,7 +102,9 @@ final class TitlebarDragView: NSView {
     override func hitTest(_ point: NSPoint) -> NSView? {
         let local = convert(point, from: superview)
         guard bounds.contains(local) else { return nil }
+        // Leave space for window buttons (left) and toolbar buttons (right)
         if local.x < AppDelegate.windowButtonsWidth { return nil }
+        if local.x > bounds.width - AppDelegate.toolbarButtonsWidth { return nil }
         return self
     }
 }

--- a/Sources/CCPlanView/Resources/index.html
+++ b/Sources/CCPlanView/Resources/index.html
@@ -80,6 +80,15 @@
         [data-color-mode="dark"] .code-line-deleted {
             background-color: rgba(255, 220, 224, 0.15);
         }
+        /* Hide diff when disabled */
+        .diff-hidden .changed-block,
+        .diff-hidden .code-line-changed {
+            background-color: transparent;
+        }
+        .diff-hidden .deleted-block,
+        .diff-hidden .code-line-deleted {
+            display: none;
+        }
     </style>
 </head>
 <body>
@@ -110,9 +119,15 @@
         });
 
         let previousTokens = null;
+        let diffEnabled = true;
 
         function resetDiff() {
             previousTokens = null;
+        }
+
+        function setDiffEnabled(enabled) {
+            diffEnabled = enabled;
+            document.body.classList.toggle('diff-hidden', !enabled);
         }
 
         function range(count) {
@@ -549,7 +564,12 @@
             const hasChanges = diffResult &&
                 (diffResult.changes.size > 0 || diffResult.deletions.length > 0);
 
-            if (hasChanges) {
+            // Notify Swift about diff status
+            if (window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers.diffStatus) {
+                window.webkit.messageHandlers.diffStatus.postMessage({ hasDiff: hasChanges });
+            }
+
+            if (hasChanges && diffEnabled) {
                 let firstChanged = null;
                 const setFirst = el => { if (firstChanged === null) firstChanged = el; };
 


### PR DESCRIPTION
## Summary

Diffハイライトの表示/非表示を切り替える機能を追加。

- ツールバーに±アイコンのトグルボタンを追加
- View メニューに「Show Diff / Hide Diff」項目を追加（⌘D ショートカット）
- Diffがない場合はツールバーボタンを非表示に
- CSSトグル方式で可逆的なハイライト切り替えを実現

## Technical Details

- `WKScriptMessageHandler` でJS→Swift間のdiffステータス通知を実装
- `FocusedValues` でウィンドウごとのdiff状態をメニューと連携
- `TitlebarDragView` の右側にもマージンを追加してツールバーボタンをクリック可能に

## Test Plan

- [ ] アプリを起動し、マークダウンファイルを開く
- [ ] ファイルを外部で編集し、リフレッシュでdiffが表示されることを確認
- [ ] ツールバーボタンをクリックしてdiffが非表示になることを確認
- [ ] ⌘D でdiffがトグルされることを確認
- [ ] diffがない状態でツールバーボタンが非表示になることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)