### PR TITLE
Fix empty lines remaining when diff is hidden

### DIFF
--- a/Sources/CCPlanView/CCPlanViewApp.swift
+++ b/Sources/CCPlanView/CCPlanViewApp.swift
@@ -22,6 +22,7 @@ struct CCPlanViewApp: App {
         DocumentGroup(viewing: MarkdownFileDocument.self) { file in
             MainContentView(document: file.document, fileURL: file.fileURL)
         }
+        .defaultSize(width: 800, height: 900)
         .defaultWindowPlacement { _, _ in
             let defaultSize = CGSize(width: 800, height: 900)
             if let frameString = UserDefaults.standard.string(forKey: AppDelegate.windowFrameKey) {

--- a/Sources/CCPlanView/MarkdownWebView.swift
+++ b/Sources/CCPlanView/MarkdownWebView.swift
@@ -18,6 +18,7 @@ struct MarkdownWebView: NSViewRepresentable {
         config.preferences.setValue(true, forKey: "allowFileAccessFromFileURLs")
         config.userContentController.add(context.coordinator, name: "diffStatus")
         let webView = WKWebView(frame: .zero, configuration: config)
+        webView.isInspectable = true
         webView.underPageBackgroundColor = .white
         let container = DropContainerView(webView: webView)
         container.onFileDrop = onFileDrop

--- a/Sources/CCPlanView/Resources/index.html
+++ b/Sources/CCPlanView/Resources/index.html
@@ -62,17 +62,22 @@
         [data-color-mode="dark"] .markdown-body table tr.deleted-block > th {
             background-color: rgba(255, 220, 224, 0.15);
         }
+        /* Override github-markdown.css inline display for code with diff spans */
+        .markdown-body pre > code {
+            display: block !important;
+        }
+        .code-line {
+            display: block;
+        }
         .code-line-changed {
             background-color: #dcffdc;
-            display: inline-block;
-            width: 100%;
+            display: block;
         }
         .code-line-deleted {
             background-color: #ffdce0;
             text-decoration: line-through;
             opacity: 0.7;
-            display: inline-block;
-            width: 100%;
+            display: block;
         }
         [data-color-mode="dark"] .code-line-changed {
             background-color: rgba(220, 255, 220, 0.15);
@@ -88,6 +93,12 @@
         .diff-hidden .deleted-block,
         .diff-hidden .code-line-deleted {
             display: none;
+            height: 0;
+            margin: 0;
+            padding: 0;
+            line-height: 0;
+            font-size: 0;
+            overflow: hidden;
         }
     </style>
 </head>
@@ -753,11 +764,11 @@
                                     newHTMLLines.push(`<span class="code-line-deleted">${escHtml(dLine)}</span>`);
                                 }
                                 deletedByIdx.delete(li);
-                                newHTMLLines.push(hl);
+                                newHTMLLines.push(`<span class="code-line">${hl}</span>`);
                             } else if (cd.changed.has(li)) {
                                 newHTMLLines.push(`<span class="code-line-changed">${hl}</span>`);
                             } else {
-                                newHTMLLines.push(hl);
+                                newHTMLLines.push(`<span class="code-line">${hl}</span>`);
                             }
                         }
                         for (const [, lines] of deletedByIdx) {
@@ -766,7 +777,7 @@
                             }
                         }
 
-                        codeEl.innerHTML = newHTMLLines.join('\n');
+                        codeEl.innerHTML = newHTMLLines.join('');
                         setFirst(el);
                     } else if (detail.type === 'blockquote') {
                         const bqDiff = detail.bqDiff;
@@ -863,13 +874,13 @@
                                     } else if (deletedByIdx.has(li)) {
                                         for (const d of deletedByIdx.get(li)) newHTMLLines.push(`<span class="code-line-deleted">${escHtml(d)}</span>`);
                                         deletedByIdx.delete(li);
-                                        newHTMLLines.push(hl);
+                                        newHTMLLines.push(`<span class="code-line">${hl}</span>`);
                                     } else if (cd.changed.has(li)) {
                                         newHTMLLines.push(`<span class="code-line-changed">${hl}</span>`);
-                                    } else { newHTMLLines.push(hl); }
+                                    } else { newHTMLLines.push(`<span class="code-line">${hl}</span>`); }
                                 }
                                 for (const [, lines] of deletedByIdx) { for (const d of lines) newHTMLLines.push(`<span class="code-line-deleted">${escHtml(d)}</span>`); }
-                                codeEl.innerHTML = newHTMLLines.join('\n');
+                                codeEl.innerHTML = newHTMLLines.join('');
                                 setFirst(subEl);
                             } else if (subDetail.type === 'blockquote') {
                                 // Nested blockquote — mark as changed (full recursive rendering is complex)


### PR DESCRIPTION
## Summary

diff表示を無効にした際、コードブロック内の削除行（赤い行）が非表示になっても空行として残ってしまう問題を修正しました。

## Changes

- コードブロック内の全ての行を `<span>` で囲み、`display: block` で統一的にレイアウト
- github-markdown.css の `<code>` 要素の `display: inline` を上書き
- `.diff-hidden` 時の削除行に対して、完全に折りたたむための追加CSSを適用
- 開発用に WKWebView の inspector を有効化

## Test Plan

- [ ] コードブロックを含むmarkdownファイルを開く
- [ ] コードブロック内の行を編集してdiffを表示させる
- [ ] Cmd+D でdiff表示をオフにする
- [ ] 削除行が空行を残さず完全に消えることを確認
- [ ] Cmd+D でdiff表示をオンに戻し、正常に表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)