### PR TITLE
Add notifier CLI and hook cleanup feature

### DIFF
--- a/Sources/CCPlanView/MarkdownWebView.swift
+++ b/Sources/CCPlanView/MarkdownWebView.swift
@@ -1,6 +1,9 @@
 import Foundation
+import os
 import SwiftUI
 import WebKit
+
+private let logger = Logger(subsystem: "sh.saqoo.ccplanview", category: "MarkdownWebView")
 
 struct MarkdownWebView: NSViewRepresentable {
     let markdown: String
@@ -188,7 +191,11 @@ struct MarkdownWebView: NSViewRepresentable {
                 NSDocumentController.shared.openDocument(
                     withContentsOf: url,
                     display: true
-                ) { _, _, _ in }
+                ) { _, _, error in
+                    if let error = error {
+                        logger.error("Failed to open document \(url.path): \(error.localizedDescription)")
+                    }
+                }
             } else {
                 // Non-markdown → open with default app
                 NSWorkspace.shared.open(url)

--- a/Sources/notifier/main.swift
+++ b/Sources/notifier/main.swift
@@ -1,0 +1,72 @@
+import Foundation
+
+/// CCPlanView Hook Notifier
+/// This CLI tool is called by Claude Code hooks to notify CCPlanView
+/// when plan mode is exited, opening the latest plan file.
+
+// Find the latest plan file
+let plansDir = FileManager.default.homeDirectoryForCurrentUser
+    .appendingPathComponent(".claude/plans")
+
+guard FileManager.default.fileExists(atPath: plansDir.path) else {
+    // No plans directory, exit silently
+    exit(0)
+}
+
+let contents: [URL]
+do {
+    contents = try FileManager.default.contentsOfDirectory(
+        at: plansDir,
+        includingPropertiesForKeys: [.contentModificationDateKey],
+        options: [.skipsHiddenFiles]
+    )
+} catch {
+    exit(0)
+}
+
+// Filter for markdown files and sort by modification date
+let mdFiles = contents.filter { url in
+    let ext = url.pathExtension.lowercased()
+    return ["md", "markdown", "mdown", "mkd"].contains(ext)
+}
+
+guard !mdFiles.isEmpty else {
+    exit(0)
+}
+
+let sortedFiles = mdFiles.sorted { url1, url2 in
+    let date1 = (try? url1.resourceValues(forKeys: [.contentModificationDateKey]))?.contentModificationDate ?? .distantPast
+    let date2 = (try? url2.resourceValues(forKeys: [.contentModificationDateKey]))?.contentModificationDate ?? .distantPast
+    return date1 > date2
+}
+
+guard let latestFile = sortedFiles.first else {
+    exit(0)
+}
+
+// Resolve symlinks to get the real path
+let resolvedPath = latestFile.resolvingSymlinksInPath().path
+
+// URL encode the path using a safe character set (RFC 3986 unreserved characters)
+let allowedCharacters = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-._~"))
+guard let encodedPath = resolvedPath.addingPercentEncoding(withAllowedCharacters: allowedCharacters) else {
+    exit(1)
+}
+
+// Open the file in CCPlanView
+let openProcess = Process()
+openProcess.executableURL = URL(fileURLWithPath: "/usr/bin/open")
+openProcess.arguments = ["-a", "CCPlanView", resolvedPath]
+try? openProcess.run()
+openProcess.waitUntilExit()
+
+// Small delay to let the app open
+Thread.sleep(forTimeInterval: 0.5)
+
+// Send refresh notification via URL scheme
+let refreshURL = URL(string: "ccplanview://refresh?file=\(encodedPath)")!
+let urlProcess = Process()
+urlProcess.executableURL = URL(fileURLWithPath: "/usr/bin/open")
+urlProcess.arguments = [refreshURL.absoluteString]
+try? urlProcess.run()
+urlProcess.waitUntilExit()

--- a/project.yml
+++ b/project.yml
@@ -8,8 +8,8 @@ options:
 
 settings:
   base:
-    MARKETING_VERSION: "1.9.0"
-    CURRENT_PROJECT_VERSION: "17"
+    MARKETING_VERSION: "1.10.0"
+    CURRENT_PROJECT_VERSION: "18"
     SWIFT_VERSION: "6.0"
     MACOSX_DEPLOYMENT_TARGET: "15.0"
 
@@ -21,6 +21,12 @@ targets:
       - path: Sources/CCPlanView
         excludes:
           - "**/.DS_Store"
+    dependencies:
+      - target: notifier
+        embed: true
+        codeSign: true
+        copy:
+          destination: executables
     settings:
       PRODUCT_BUNDLE_IDENTIFIER: sh.saqoo.ccplanview
       PRODUCT_NAME: "CCPlanView"
@@ -74,3 +80,16 @@ targets:
                 - markdown
                 - mdown
                 - mkd
+
+  notifier:
+    type: tool
+    platform: macOS
+    sources:
+      - path: Sources/notifier
+        excludes:
+          - "**/.DS_Store"
+    settings:
+      PRODUCT_NAME: "notifier"
+      CODE_SIGN_STYLE: Automatic
+      DEVELOPMENT_TEAM: G5G54TCH8W
+      ENABLE_HARDENED_RUNTIME: YES


### PR DESCRIPTION
## Summary

This PR adds a bundled CLI tool (`notifier`) for Claude Code hook integration and improves hook management.

### New Features
- **Notifier CLI tool** (`Contents/MacOS/notifier`)
  - Finds the latest plan file from `~/.claude/plans/`
  - Opens CCPlanView and sends refresh notification via URL scheme
  - Uses safe URL encoding (RFC 3986 unreserved characters)
  
- **Dynamic path resolution**
  - Uses `Bundle.main.bundlePath` instead of hardcoded `/Applications/`
  - Hook works correctly in both development and production environments

- **Hook cleanup feature**
  - `needsHookUpdate()` detects legacy, wrong path, or duplicate hooks
  - `cleanupAndInstallHook()` removes ALL old hooks and installs a fresh one
  - Automatic prompt on app launch when cleanup is needed
  - All operations in single file coordination block to prevent race conditions

- **Settings validation**
  - Detects corrupted/unreadable `settings.json`
  - Shows warning dialog with error details

### Bug Fixes
- Fix notarize.sh to sign all executables in `Contents/MacOS/`
- Add error logging in MarkdownWebView

### Version
- Bump to 1.10.0

## Test Plan
- [x] Unit tests pass (22/22)
- [x] Debug build succeeds
- [ ] Release build and notarization
- [ ] Test hook trigger with ExitPlanMode

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)