### PR TITLE
Add Print menu for PDF export

### DIFF
--- a/Sources/CCPlanView/CCPlanViewApp.swift
+++ b/Sources/CCPlanView/CCPlanViewApp.swift
@@ -1,6 +1,7 @@
 import AppKit
 import CCHookInstaller
 import SwiftUI
+import WebKit
 
 struct ShowDiffKey: FocusedValueKey {
     typealias Value = Binding<Bool>
@@ -69,6 +70,25 @@ struct CCPlanViewApp: App {
                     isHookConfigured = HookManager.isHookConfigured()
                 }
             }
+            CommandGroup(replacing: .printItem) {
+                Button("Print…") {
+                    guard let window = NSApp.keyWindow,
+                          let webView = Self.findWebView(in: window.contentView)
+                    else { return }
+                    let printInfo = NSPrintInfo.shared.copy() as! NSPrintInfo
+                    printInfo.topMargin = 36
+                    printInfo.bottomMargin = 36
+                    printInfo.leftMargin = 36
+                    printInfo.rightMargin = 36
+                    printInfo.isHorizontallyCentered = true
+                    printInfo.isVerticallyCentered = false
+                    let printOp = webView.printOperation(with: printInfo)
+                    printOp.showsPrintPanel = true
+                    printOp.showsProgressPanel = true
+                    printOp.runModal(for: window, delegate: nil, didRun: nil, contextInfo: nil)
+                }
+                .keyboardShortcut("p", modifiers: .command)
+            }
             CommandGroup(after: .toolbar) {
                 Button(showDiff?.wrappedValue == true ? "Hide Diff" : "Show Diff") {
                     showDiff?.wrappedValue.toggle()
@@ -85,6 +105,15 @@ struct CCPlanViewApp: App {
                 .disabled(refreshAction == nil)
             }
         }
+    }
+
+    private static func findWebView(in view: NSView?) -> WKWebView? {
+        guard let view else { return nil }
+        if let webView = view as? WKWebView { return webView }
+        for subview in view.subviews {
+            if let found = findWebView(in: subview) { return found }
+        }
+        return nil
     }
 
     private func installHook() {

--- a/Sources/CCPlanView/Resources/index.html
+++ b/Sources/CCPlanView/Resources/index.html
@@ -110,6 +110,33 @@
             max-width: 100%;
             height: auto;
         }
+        @media print {
+            body {
+                padding-top: 0 !important;
+                background: #ffffff !important;
+            }
+            html[data-color-mode="dark"] body {
+                background: #ffffff !important;
+                color: #1f2328 !important;
+            }
+            .markdown-body {
+                padding: 0 !important;
+                max-width: none !important;
+                color: #1f2328 !important;
+                zoom: 0.65;
+            }
+            .mermaid-container {
+                page-break-inside: avoid;
+            }
+            .deleted-block,
+            .code-line-deleted {
+                display: none !important;
+            }
+            .changed-block,
+            .code-line-changed {
+                background-color: transparent !important;
+            }
+        }
     </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- Add **File > Print… (⌘P)** menu command using WKWebView's native `printOperation`
- Add `@media print` CSS for clean PDF output: remove titlebar padding, force light mode, hide diffs, `zoom: 0.65` for compact sizing
- Add `page-break-inside: avoid` for Mermaid diagrams

## Test plan
- [ ] Open a markdown file with text and Mermaid diagrams
- [ ] File > Print… (⌘P) opens the macOS print dialog
- [ ] "Save as PDF" produces clean output with readable font sizes
- [ ] Mermaid diagram fonts match body text proportionally
- [ ] Dark mode documents print in light mode
- [ ] Cancel print dialog returns to normal view

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新機能
* 印刷機能を追加しました。⌘P キーボードショートカットで印刷ダイアログを開くことができます。

## スタイル
* 印刷出力の表示を最適化しました。削除済みコンテンツを非表示にし、背景色をクリアし、図表が改ページされることを防止します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->