### PR TITLE
Reload images linked in markdown on refresh

### DIFF
--- a/Sources/CCPlanView/CCPlanViewApp.swift
+++ b/Sources/CCPlanView/CCPlanViewApp.swift
@@ -160,6 +160,7 @@ struct MainContentView: View {
     @State private var hasDiff: Bool = false
     @State private var fileWatcher: FileWatcher?
     @State private var needsReload: Bool = false
+    @State private var reloadID: Int = 0
 
     private var backgroundColor: Color {
         colorScheme == .dark
@@ -176,6 +177,7 @@ struct MainContentView: View {
                     markdown: renderedMarkdown,
                     fileURL: fileURL,
                     showDiff: showDiff,
+                    reloadID: reloadID,
                     onFileDrop: { url in
                         openFile(url)
                     }
@@ -271,6 +273,9 @@ struct MainContentView: View {
         guard let fileURL else { return }
         if let data = try? Data(contentsOf: fileURL) {
             renderedMarkdown = String(decoding: data, as: UTF8.self)
+            // Bump reloadID so images re-fetch even if markdown text is identical
+            // (the file on disk may be unchanged while linked image files updated).
+            reloadID &+= 1
             needsReload = false
         }
     }

--- a/Sources/CCPlanView/MarkdownWebView.swift
+++ b/Sources/CCPlanView/MarkdownWebView.swift
@@ -9,6 +9,7 @@ struct MarkdownWebView: NSViewRepresentable {
     let markdown: String
     let fileURL: URL?
     let showDiff: Bool
+    let reloadID: Int
     let onFileDrop: (URL) -> Void
     @Environment(\.colorScheme) private var colorScheme
 
@@ -52,6 +53,12 @@ struct MarkdownWebView: NSViewRepresentable {
         let fileChanged = context.coordinator.lastFileURL != fileURL
         let themeChanged = context.coordinator.lastIsDarkMode != isDarkMode
         let contentChanged = context.coordinator.lastMarkdown != markdown
+        // Detect an explicit reload request. The caller initializes reloadID at 0
+        // (MainContentView's @State) and the coordinator's lastReloadID is also 0,
+        // so the first update is not a reload — refreshContent() bumps the value
+        // to force a re-render even when the markdown text hasn't changed.
+        let reloadRequested = context.coordinator.lastReloadID != reloadID
+        context.coordinator.lastReloadID = reloadID
 
         if fileChanged {
             context.coordinator.lastFileURL = fileURL
@@ -75,7 +82,7 @@ struct MarkdownWebView: NSViewRepresentable {
             webView.evaluateJavaScript(js)
         }
 
-        if contentChanged {
+        if contentChanged || reloadRequested {
             context.coordinator.lastMarkdown = markdown
             let escaped = Self.escapeForJS(markdown)
             webView.evaluateJavaScript("renderMarkdown(`\(escaped)`);")
@@ -111,6 +118,7 @@ struct MarkdownWebView: NSViewRepresentable {
         var lastIsDarkMode: Bool?
         var lastFileURL: URL?
         var lastShowDiff: Bool?
+        var lastReloadID: Int = 0
         var isPageLoaded = false
         var pendingMarkdown: String?
         var pendingIsDarkMode: Bool?

--- a/Sources/CCPlanView/Resources/index.html
+++ b/Sources/CCPlanView/Resources/index.html
@@ -627,6 +627,29 @@
                     (match, prefix, path, suffix) => prefix + fileBase + path + suffix);
         }
 
+        // Append a cache-busting query to <img src=...> so reloads fetch fresh
+        // bytes instead of WebKit's in-memory image cache. http(s) and data:
+        // URLs are skipped; everything else (file://, absolute paths, and any
+        // relative paths that slipped past resolveImagePaths) gets stamped.
+        // A pre-existing #fragment is preserved by inserting "?_t=…" before it.
+        function addImageCacheBusters(html) {
+            const stamp = Date.now();
+            return html.replace(/(<img[^>]*?\s+src=)(["'])([^"']+)\2/gi, (match, prefix, quote, src) => {
+                if (/^(https?:|data:)/i.test(src)) return match;
+                const hashIdx = src.indexOf('#');
+                const base = hashIdx === -1 ? src : src.slice(0, hashIdx);
+                const fragment = hashIdx === -1 ? '' : src.slice(hashIdx);
+                const sep = base.indexOf('?') === -1 ? '?' : '&';
+                return `${prefix}${quote}${base}${sep}_t=${stamp}${fragment}${quote}`;
+            });
+        }
+
+        // Convenience for the diff-rendering branches so deleted/modified-old
+        // blocks get the same cache-busting treatment as the main render.
+        function parseMarkdownWithBusters(raw) {
+            return addImageCacheBusters(marked.parse(raw));
+        }
+
         function renderMarkdown(source) {
             const contentEl = document.getElementById('content');
             const scrollRatio = document.documentElement.scrollHeight > 0
@@ -644,7 +667,7 @@
             }
             previousTokens = newTokens;
 
-            contentEl.innerHTML = marked.parse(source);
+            contentEl.innerHTML = addImageCacheBusters(marked.parse(source));
 
             // Separate mermaid blocks from regular code blocks
             const mermaidBlocks = [];
@@ -697,7 +720,7 @@
                 function insertOldBlock(oldToken, beforeEl) {
                     const wrapper = document.createElement('div');
                     wrapper.classList.add('deleted-block');
-                    wrapper.innerHTML = marked.parse(oldToken.raw);
+                    wrapper.innerHTML = parseMarkdownWithBusters(oldToken.raw);
                     if (beforeEl) {
                         contentEl.insertBefore(wrapper, beforeEl);
                     } else {
@@ -735,7 +758,7 @@
                         const delLi = document.createElement('li');
                         delLi.classList.add('deleted-block');
                         // Use raw to preserve nested lists and block content
-                        const parsedItem = marked.parse(item.raw);
+                        const parsedItem = parseMarkdownWithBusters(item.raw);
                         // marked.parse wraps in <ul><li>...</li></ul>, extract inner li content
                         const tmpLi = document.createElement('div');
                         tmpLi.innerHTML = parsedItem;
@@ -897,7 +920,7 @@
                         for (const { beforeNewIdx, token: delToken } of bqDiff.deletions) {
                             const wrapper = document.createElement('div');
                             wrapper.classList.add('deleted-block');
-                            wrapper.innerHTML = marked.parse(delToken.raw);
+                            wrapper.innerHTML = parseMarkdownWithBusters(delToken.raw);
                             // Extract inner content (marked.parse wraps in tags)
                             const refChild = bqChildren[beforeNewIdx] || null;
                             if (refChild) {
@@ -920,7 +943,7 @@
                                 subEl.classList.add('changed-block');
                                 const oldWrapper = document.createElement('div');
                                 oldWrapper.classList.add('deleted-block');
-                                oldWrapper.innerHTML = marked.parse(subDetail.oldToken.raw);
+                                oldWrapper.innerHTML = parseMarkdownWithBusters(subDetail.oldToken.raw);
                                 el.insertBefore(oldWrapper, subEl);
                                 setFirst(oldWrapper);
                             } else if (subDetail.type === 'list') {


### PR DESCRIPTION
## Summary
- Reload button (toolbar / ⌘R / `ccplanview://refresh` URL) was leaving linked images stale because WKWebView's image cache served the previously-loaded bytes for the same `file://` URL
- Cache-bust local image URLs with `?_t=<Date.now()>` at render time so each reload fetches fresh bytes from disk; HTTP(S) and `data:` URLs are left alone
- Force `renderMarkdown` to re-run on reload even when the markdown text is identical, so editing only the image file (not the `.md`) still updates the view

## Test plan
- [ ] Open a markdown file containing a relative image, edit only the image (markdown text unchanged), press ⌘R → image refreshes
- [ ] Edit both the markdown text and the image, press the toolbar Reload → diff banner and new image both render
- [ ] Markdown with an HTTP image or a `data:` URL still loads (cache buster not applied)
- [ ] File watcher → notification → reload path still works end-to-end

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * マークダウンに含まれる画像やリソースの更新検出が改善されました。マークダウン本文の内容が変わらない場合でも、リンク先の画像などが確実に再読込され、常に最新版が表示されるようになりました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Saqoosha/CCPlanView/pull/19?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->