### PR TITLE
Catch file changes that kqueue misses

### DIFF
--- a/Sources/CCPlanView/FileWatcher.swift
+++ b/Sources/CCPlanView/FileWatcher.swift
@@ -6,38 +6,57 @@ import os
 final class FileWatcher {
     private var source: DispatchSourceFileSystemObject?
     private var debounceWorkItem: DispatchWorkItem?
+    private var pollTimer: DispatchSourceTimer?
     private let fileURL: URL
     private let onChange: () -> Void
     private let logger = Logger(subsystem: "sh.saqoo.ccplanview", category: "FileWatcher")
     private var lastModificationDate: Date?
+    private var lastFileSize: Int64?
     private var needsRewatch = false
 
     init(fileURL: URL, onChange: @escaping () -> Void) {
         self.fileURL = fileURL
         self.onChange = onChange
-        self.lastModificationDate = getModificationDate()
+        let attrs = getFileAttributes()
+        self.lastModificationDate = attrs.modDate
+        self.lastFileSize = attrs.size
         startWatching()
+        startPolling()
     }
 
-    private func getModificationDate() -> Date? {
+    private func getFileAttributes() -> (modDate: Date?, size: Int64?) {
         do {
             let attrs = try FileManager.default.attributesOfItem(atPath: fileURL.path)
-            return attrs[.modificationDate] as? Date
+            let modDate = attrs[.modificationDate] as? Date
+            let size = (attrs[.size] as? NSNumber)?.int64Value
+            return (modDate, size)
         } catch {
-            logger.debug(
-                "Cannot read modification date: \(self.fileURL.path, privacy: .public): \(error.localizedDescription, privacy: .public)"
+            // .info so the failure shows up in `log stream` at default level;
+            // a file we're actively watching becoming unreadable is a real
+            // signal, not debug noise.
+            logger.info(
+                "Cannot read file attributes: \(self.fileURL.path, privacy: .public): \(error.localizedDescription, privacy: .public)"
             )
-            return nil
+            return (nil, nil)
         }
     }
 
     private func startWatching() {
         let fd = open(fileURL.path, O_EVTONLY)
         guard fd >= 0 else {
-            logger.error("Failed to open file for watching: \(self.fileURL.path, privacy: .public)")
+            let errnoMessage = String(cString: strerror(errno))
+            // The 2s poll timer is still running so changes are still detectable,
+            // just at poll latency instead of kqueue latency. Call that out so a
+            // future maintainer reading logs doesn't conclude the watcher is dead.
+            logger.error(
+                "kqueue unavailable for \(self.fileURL.path, privacy: .public) (errno \(errno): \(errnoMessage, privacy: .public)) — continuing with 2s poll fallback only."
+            )
             return
         }
+        setupSource(fd: fd)
+    }
 
+    private func setupSource(fd: Int32) {
         let source = DispatchSource.makeFileSystemObjectSource(
             fileDescriptor: fd,
             eventMask: [.write, .extend, .attrib, .delete, .rename],
@@ -85,22 +104,53 @@ final class FileWatcher {
                     self?.restartWatching(retryCount: retryCount + 1)
                 }
             } else {
+                let errnoMessage = String(cString: strerror(errno))
                 logger.error(
-                    "Failed to restart watching after 5 retries: \(self.fileURL.path, privacy: .public)"
+                    "kqueue rewatch failed after 5 retries for \(self.fileURL.path, privacy: .public) (errno \(errno): \(errnoMessage, privacy: .public)) — continuing with 2s poll fallback only."
                 )
             }
             return
         }
-        close(fd)
-        startWatching()
+        // Use this fd directly instead of closing and reopening — the file can
+        // disappear between the two opens during atomic saves, leaving the
+        // watcher unset.
+        setupSource(fd: fd)
+        // Catch any change that landed between the cancel and the new fd —
+        // kqueue cannot deliver events during that window.
+        checkForChanges()
     }
 
     private func checkForChanges() {
-        let currentModDate = getModificationDate()
-        if currentModDate != lastModificationDate {
-            lastModificationDate = currentModDate
+        let attrs = getFileAttributes()
+        // Compare both modification date and file size. Mod date alone misses
+        // tools that preserve mtime while changing content (touch -t, scripted
+        // restores) — size catches those.
+        if attrs.modDate != lastModificationDate || attrs.size != lastFileSize {
+            lastModificationDate = attrs.modDate
+            lastFileSize = attrs.size
             onChange()
         }
+    }
+
+    // Polling fallback for kqueue events that get dropped or coalesced — e.g.
+    // changes landing while restartWatching is between fds, or multiple writes
+    // within the kqueue debounce window that share an mtime. 2-second cadence
+    // balances responsiveness against wakeups.
+    //
+    // The timer MUST stay on .main because the event handler uses
+    // MainActor.assumeIsolated to call checkForChanges() without an actor hop.
+    private func startPolling() {
+        pollTimer?.cancel()
+        let timer = DispatchSource.makeTimerSource(queue: .main)
+        timer.schedule(deadline: .now() + 2, repeating: 2)
+        timer.setEventHandler { [weak self] in
+            guard let self else { return }
+            MainActor.assumeIsolated {
+                self.checkForChanges()
+            }
+        }
+        timer.resume()
+        pollTimer = timer
     }
 
     func stop() {
@@ -108,9 +158,12 @@ final class FileWatcher {
         source = nil
         debounceWorkItem?.cancel()
         debounceWorkItem = nil
+        pollTimer?.cancel()
+        pollTimer = nil
     }
 
     deinit {
         source?.cancel()
+        pollTimer?.cancel()
     }
 }


### PR DESCRIPTION
## Summary
- Toolbar Reload button sometimes stayed disabled even after the markdown file changed. Kqueue can drop events during atomic-save races (the rewatch gap between `cancel()` and a new `open()`), and tools that preserve mtime don't trip the existing mod-date check at all
- Added a 2-second polling fallback (`DispatchSource` timer on main) that re-checks file attributes — catches anything kqueue misses without noticeable delay
- Track file size alongside modification date so size-only changes also fire `onChange`
- Run `checkForChanges()` once at the end of `restartWatching` to catch changes that land during the cancel→reopen window

## Test plan
- [ ] 10 rapid atomic saves (write-temp + mv) → toolbar Reload becomes enabled
- [ ] Change file content while keeping mtime fixed (`touch -t`) → toolbar Reload becomes enabled within ~2s (polling)
- [ ] Single in-place write → toolbar Reload becomes enabled
- [ ] Click Reload to consume → button disables again; next change re-enables it
- [ ] No regression to the image-reload behavior shipped in #19 (markdown text unchanged + image swapped + ⌘R still refreshes images)